### PR TITLE
feat: apply grammar feedback prompt in LLM service

### DIFF
--- a/src/prompts/chatWithFeedback.prompt.js
+++ b/src/prompts/chatWithFeedback.prompt.js
@@ -1,4 +1,5 @@
-export const chatWithGrammarFeedbackPrompt = `
+export function chatWithGrammarFeedbackPrompt(userMessage) {
+  return `
 You are a friendly English conversation tutor.
 
 Your tasks:
@@ -11,6 +12,9 @@ Important rules:
 - Do NOT correct style or vocabulary unless it is a grammar mistake.
 - If there are no grammar mistakes, say so politely.
 - Always follow the response format exactly.
+
+User message:
+"${userMessage}"
 
 Response format:
 
@@ -27,3 +31,4 @@ If there are no mistakes, use:
 FEEDBACK:
 No grammar mistakes found. Great job!
 `;
+}

--- a/src/services/llm.service.js
+++ b/src/services/llm.service.js
@@ -1,5 +1,6 @@
 import Groq from "groq-sdk";
 import { llmConfig } from "../config/llm.config.js";
+import { chatWithGrammarFeedbackPrompt } from "../prompts/chatWithFeedback.prompt.js";
 
 let client;
 
@@ -12,6 +13,7 @@ if (llmConfig.provider === "groq") {
 }
 
 export async function sendPrompt(message) {
+  const prompt = chatWithGrammarFeedbackPrompt(message);
   try {
     const response = await client.chat.completions.create({
       model: llmConfig.model,
@@ -23,7 +25,7 @@ export async function sendPrompt(message) {
         },
         {
           role: "user",
-          content: message,
+          content: prompt,
         },
       ],
     });


### PR DESCRIPTION
## Summary
Apply a structured grammar feedback prompt in the LLM service:
- Introduced a dedicated prompt for conversation + grammar correction 
- Enforced a strict response format (`REPLY` / `FEEDBACK`) from the LLM
- Added dynamic prompt generation with user message injection
- Improved prompt maintainability and readability

## Type of change
- [ ] Chore / infrastructure
- [x] Feature
- [ ] Bugfix
- [ ] Refactor

## How to test
1. Install dependencies: `npm install`
2. Run the server locally: `npm run dev`
3. Send a chat request with a message containing grammar mistakes
4. Verify the response includes:
    - A natural conversational reply
    - A structured grammar feedback section

## Related issues
Closes #17